### PR TITLE
Pretty print JSON/XML payload when sayAndMakeRequest(Request)

### DIFF
--- a/doctester-core/pom.xml
+++ b/doctester-core/pom.xml
@@ -63,11 +63,11 @@
 					</dependency>
 				</dependencies>
 			</plugin>
-			
+
                         <!-- DEACTIVATED TEMPORARILY UNTIL
                              SUPPORT FOR FINBUGS 3.0.0 IS THERE...
                              WHY?
-                             BECAUSE findbugs-maven-plugin 2.5.4 IS 
+                             BECAUSE findbugs-maven-plugin 2.5.4 IS
                              NOT COMPATIBLE WITH JAVA 1.8.
                              http://stackoverflow.com/questions/17259201/findbugs-in-eclipse-arrayindexoutofbounds-exception-when-running
 			<plugin>
@@ -92,7 +92,7 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 			</plugin>
-			
+
 		</plugins>
 
 		<resources>
@@ -191,6 +191,12 @@
 			<version>${jackson.version}</version>
 		</dependency>
 
+		<!-- Woodstox XML processor for Jackson XML -->
+		<dependency>
+			<groupId>org.codehaus.woodstox</groupId>
+			<artifactId>woodstox-core-asl</artifactId>
+			<version>4.1.4</version>
+		</dependency>
 
 		<!-- We use slf4j for logging -->
 		<dependency>
@@ -198,14 +204,14 @@
 			<artifactId>slf4j-api</artifactId>
 			<version>1.7.6</version>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-simple</artifactId>
 			<version>1.7.6</version>
 			<scope>test</scope>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>jcl-over-slf4j</artifactId>
@@ -223,5 +229,5 @@
 		</site>
 
 	</distributionManagement>
-		
+
 </project>

--- a/doctester-core/src/main/java/org/doctester/rendermachine/RenderMachineHtml.java
+++ b/doctester-core/src/main/java/org/doctester/rendermachine/RenderMachineHtml.java
@@ -44,7 +44,7 @@ public interface RenderMachineHtml {
             + "    padding-top: 100px;\n"
             + "    padding-bottom: 20px;\n"
             + "  }\n"
-            + "  div.http-body {\n"
+            + "  div.http-response-body, div.http-request-body {\n"
             + "    max-height:200px;\n"
             + "    overflow:auto;\n"
             + "  }\n"

--- a/doctester-core/src/main/java/org/doctester/rendermachine/RenderMachineHtml.java
+++ b/doctester-core/src/main/java/org/doctester/rendermachine/RenderMachineHtml.java
@@ -44,7 +44,7 @@ public interface RenderMachineHtml {
             + "    padding-top: 100px;\n"
             + "    padding-bottom: 20px;\n"
             + "  }\n"
-            + "  div.http-response-body {\n"
+            + "  div.http-body {\n"
             + "    max-height:200px;\n"
             + "    overflow:auto;\n"
             + "  }\n"

--- a/doctester-core/src/main/java/org/doctester/rendermachine/RenderMachineImpl.java
+++ b/doctester-core/src/main/java/org/doctester/rendermachine/RenderMachineImpl.java
@@ -369,7 +369,7 @@ public class RenderMachineImpl implements RenderMachine {
         if (httpRequest.formParameters != null) {
             htmlDocument.add("<dt>Parameters</dt><dd>" + httpRequest.formParameters.toString() + "</dd>");
         } else if (httpRequest.payload != null) {
-            htmlDocument.add("<dt>Content</dt><dd><div class=\"http-body\"><pre>" + HtmlEscapers.htmlEscaper().escape(httpRequest.payloadAsPrettyString()) + "</pre></div></dd>");
+            htmlDocument.add("<dt>Content</dt><dd><div class=\"http-request-body\"><pre>" + HtmlEscapers.htmlEscaper().escape(httpRequest.payloadAsPrettyString()) + "</pre></div></dd>");
 		}
 
         htmlDocument.add("</dl>");
@@ -392,7 +392,7 @@ public class RenderMachineImpl implements RenderMachine {
         if (response.payload == null) {
             htmlDocument.add("<dt>Content</dt><dd>No Body content.</dd>");
         } else {
-            htmlDocument.add("<dt>Content</dt><dd><div class=\"http-body\"><pre>" + HtmlEscapers.htmlEscaper().escape(response.payloadAsPrettyString()) + "</pre></div></dd>");
+            htmlDocument.add("<dt>Content</dt><dd><div class=\"http-response-body\"><pre>" + HtmlEscapers.htmlEscaper().escape(response.payloadAsPrettyString()) + "</pre></div></dd>");
         }
 
         htmlDocument.add("</dl>");
@@ -420,7 +420,7 @@ public class RenderMachineImpl implements RenderMachine {
             for (Entry<String, String> header : headers.entrySet()) {
 
                 htmlStuff.add("<dt>" + header.getKey() + "</dt>");
-                htmlStuff.add("<dd><div class=\"http-body\">" + header.getValue() + "</div></dd>");
+                htmlStuff.add("<dd><div class=\"http-response-body\">" + header.getValue() + "</div></dd>");
 
             }
 

--- a/doctester-core/src/main/java/org/doctester/rendermachine/RenderMachineImpl.java
+++ b/doctester-core/src/main/java/org/doctester/rendermachine/RenderMachineImpl.java
@@ -363,11 +363,14 @@ public class RenderMachineImpl implements RenderMachine {
         htmlDocument.add("<dl class=\"dl-horizontal\">");
         htmlDocument.add("<dt>Type</dt><dd>" + httpRequest.httpRequestType + "</dd>");
         htmlDocument.add("<dt>Url</dt><dd>" + httpRequest.uri.toString() + "</dd>");
-        if (httpRequest.formParameters != null) {
-            htmlDocument.add("<dt>Parameters</dt><dd>" + httpRequest.formParameters.toString() + "</dd>");
-        }
 
         htmlDocument.addAll(getHtmlFormattedHeaders(httpRequest.headers));
+
+        if (httpRequest.formParameters != null) {
+            htmlDocument.add("<dt>Parameters</dt><dd>" + httpRequest.formParameters.toString() + "</dd>");
+        } else if (httpRequest.payload != null) {
+            htmlDocument.add("<dt>Content</dt><dd><div class=\"http-body\"><pre>" + HtmlEscapers.htmlEscaper().escape(httpRequest.payloadAsPrettyString()) + "</pre></div></dd>");
+		}
 
         htmlDocument.add("</dl>");
 
@@ -389,7 +392,7 @@ public class RenderMachineImpl implements RenderMachine {
         if (response.payload == null) {
             htmlDocument.add("<dt>Content</dt><dd>No Body content.</dd>");
         } else {
-            htmlDocument.add("<dt>Content</dt><dd><div class=\"http-response-body\"><pre>" + HtmlEscapers.htmlEscaper().escape(response.payloadAsPrettyString()) + "</pre></div></dd>");
+            htmlDocument.add("<dt>Content</dt><dd><div class=\"http-body\"><pre>" + HtmlEscapers.htmlEscaper().escape(response.payloadAsPrettyString()) + "</pre></div></dd>");
         }
 
         htmlDocument.add("</dl>");
@@ -417,7 +420,7 @@ public class RenderMachineImpl implements RenderMachine {
             for (Entry<String, String> header : headers.entrySet()) {
 
                 htmlStuff.add("<dt>" + header.getKey() + "</dt>");
-                htmlStuff.add("<dd><div class=\"http-response-body\">" + header.getValue() + "</div></dd>");
+                htmlStuff.add("<dd><div class=\"http-body\">" + header.getValue() + "</div></dd>");
 
             }
 

--- a/doctester-core/src/main/java/org/doctester/rendermachine/RenderMachineImpl.java
+++ b/doctester-core/src/main/java/org/doctester/rendermachine/RenderMachineImpl.java
@@ -370,7 +370,7 @@ public class RenderMachineImpl implements RenderMachine {
             htmlDocument.add("<dt>Parameters</dt><dd>" + httpRequest.formParameters.toString() + "</dd>");
         } else if (httpRequest.payload != null) {
             htmlDocument.add("<dt>Content</dt><dd><div class=\"http-request-body\"><pre>" + HtmlEscapers.htmlEscaper().escape(httpRequest.payloadAsPrettyString()) + "</pre></div></dd>");
-		}
+        }
 
         htmlDocument.add("</dl>");
 

--- a/doctester-core/src/main/java/org/doctester/testbrowser/PayloadUtils.java
+++ b/doctester-core/src/main/java/org/doctester/testbrowser/PayloadUtils.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (C) 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.doctester.testbrowser;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.Map;
+
+public class PayloadUtils {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    public static String prettyPrintRequestPayload(Object payload, Map<String, String> headers) throws IOException {
+
+        if (isContentTypeApplicationJson(headers)) {
+            return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(payload);
+
+        } else {
+            return "Payload not pretty-printable.";
+        }
+
+    }
+
+    public static String prettyPrintResponsePayload(String payload, Map<String, String> headers) throws IOException {
+
+        if (isContentTypeApplicationJson(headers)) {
+            return getPrettyFormattedJson(payload);
+
+        } else {
+            return payload;
+        }
+    }
+
+    public static boolean isContentTypeApplicationJson(Map<String, String> headers) {
+
+        String contentType = headers.get(HttpConstants.HEADER_CONTENT_TYPE);
+
+        return contentType != null
+                && contentType.contains(HttpConstants.APPLICATION_JSON);
+
+    }
+
+    public static boolean isContentTypeApplicationXml(Map<String, String> headers) {
+
+        String contentType = headers.get(HttpConstants.HEADER_CONTENT_TYPE);
+
+        return contentType != null
+                && contentType.contains(HttpConstants.APPLICATION_XML);
+
+    }
+
+    private static String getPrettyFormattedJson(String stringToFormatAsPrettyJson) throws IOException {
+        Object json = objectMapper.readValue(stringToFormatAsPrettyJson, Object.class);
+        return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(json);
+    }
+
+}

--- a/doctester-core/src/main/java/org/doctester/testbrowser/PayloadUtils.java
+++ b/doctester-core/src/main/java/org/doctester/testbrowser/PayloadUtils.java
@@ -16,24 +16,62 @@
 package org.doctester.testbrowser;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.xml.JacksonXmlModule;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import java.io.IOException;
 import java.util.Map;
 
+/**
+ * Provides some utility methods for HTTP request/response
+ * payload type detection and pretty-printing.
+ */
 public class PayloadUtils {
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
+    private static final XmlMapper xmlMapper;
+    static {
+        JacksonXmlModule module = new JacksonXmlModule();
+        module.setDefaultUseWrapper(false);
+        xmlMapper = new XmlMapper(module);
+    }
+
+    /**
+     * Attempts to pretty print the payload of an
+     * HTTP request based on the headers. Only JSON
+     * and XML are supported at the moment.
+     *
+     * @param payload Payload to be serialized in the request
+     * @param headers Headers, should contain "Content-Type"
+     * @return Pretty printed payload
+     * @throws IOException If something went wrong when serializing the object
+     */
     public static String prettyPrintRequestPayload(Object payload, Map<String, String> headers) throws IOException {
 
         if (isContentTypeApplicationJson(headers)) {
             return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(payload);
 
+        } else if (isContentTypeApplicationXml(headers)) {
+            return xmlMapper.writerWithDefaultPrettyPrinter().writeValueAsString(payload);
+
         } else {
-            return "Payload not pretty-printable.";
+            return "Payload not printable in the format specified by the Content-Type header.";
         }
 
     }
 
+    /**
+     * Attempts to pretty print the payload of an
+     * HTTP response based on the headers. Only JSON
+     * is supported at the moment (XML is not because
+     * its tree model cannot be read without proper target
+     * class information).
+     *
+     * @param payload Payload to be pretty printed
+     * @param headers Headers, should contain "Content-Type"
+     * @return Pretty printed payload
+     * @throws IOException If something went wrong when (de)serializing 
+     */
     public static String prettyPrintResponsePayload(String payload, Map<String, String> headers) throws IOException {
 
         if (isContentTypeApplicationJson(headers)) {
@@ -44,6 +82,12 @@ public class PayloadUtils {
         }
     }
 
+    /**
+     * Checks whether the headers define the content type to be JSON.
+     *
+     * @param headers Headers of a request or response
+     * @return true if content-type is JSON
+     */
     public static boolean isContentTypeApplicationJson(Map<String, String> headers) {
 
         String contentType = headers.get(HttpConstants.HEADER_CONTENT_TYPE);
@@ -53,6 +97,12 @@ public class PayloadUtils {
 
     }
 
+        /**
+     * Checks whether the headers define the content type to be XML.
+     *
+     * @param headers Headers of a request or response
+     * @return true if content-type is XML
+     */
     public static boolean isContentTypeApplicationXml(Map<String, String> headers) {
 
         String contentType = headers.get(HttpConstants.HEADER_CONTENT_TYPE);
@@ -62,6 +112,13 @@ public class PayloadUtils {
 
     }
 
+    /**
+     * Pretty prints a JSON formatted string.
+     *
+     * @param stringToFormatAsPrettyJson Source JSON string
+     * @return Pretty printed JSON string
+     * @throws IOException If an error occurred when (de)serializing
+     */
     private static String getPrettyFormattedJson(String stringToFormatAsPrettyJson) throws IOException {
         Object json = objectMapper.readValue(stringToFormatAsPrettyJson, Object.class);
         return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(json);

--- a/doctester-core/src/main/java/org/doctester/testbrowser/Request.java
+++ b/doctester-core/src/main/java/org/doctester/testbrowser/Request.java
@@ -300,11 +300,10 @@ public class Request {
         return this;
     }
 
-
     /**
      *
      * @return The payload of this request as String. It tries to determine the
-     * content and format the content in a pretty way. Currently works for json.
+     * content and format the content in a pretty way. Currently works for json and xml;
      *
      */
     public String payloadAsPrettyString() {

--- a/doctester-core/src/main/java/org/doctester/testbrowser/Request.java
+++ b/doctester-core/src/main/java/org/doctester/testbrowser/Request.java
@@ -20,6 +20,8 @@ import java.net.URI;
 import java.util.Map;
 
 import com.google.common.collect.Maps;
+import java.io.IOException;
+import org.slf4j.LoggerFactory;
 
 /**
  * This represents a Request we can pass then to the TestBrowser.
@@ -28,6 +30,8 @@ import com.google.common.collect.Maps;
  *
  */
 public class Request {
+
+    private final org.slf4j.Logger logger = LoggerFactory.getLogger(Response.class);
 
     public String httpRequestType;
 
@@ -294,6 +298,24 @@ public class Request {
     public Request followRedirects(boolean followRedirects) {
         this.followRedirects = followRedirects;
         return this;
+    }
+
+
+    /**
+     *
+     * @return The payload of this request as String. It tries to determine the
+     * content and format the content in a pretty way. Currently works for json.
+     *
+     */
+    public String payloadAsPrettyString() {
+
+        try {
+            return PayloadUtils.prettyPrintRequestPayload(payload, headers);
+        } catch (IOException ex) {
+            logger.error("Something went wrong when pretty printing request payload: " + ex.toString());
+            return "Error pretty printing the payload.";
+        }
+
     }
 
 }

--- a/doctester-core/src/main/java/org/doctester/testbrowser/Response.java
+++ b/doctester-core/src/main/java/org/doctester/testbrowser/Response.java
@@ -25,7 +25,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.xml.JacksonXmlModule;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import java.io.IOException;
-import java.util.logging.Level;
 
 /**
  *
@@ -193,7 +192,7 @@ public class Response {
      * The payload of this request de-serialized into the specified
      * TypeReference. The payload must be Json.
      *
-     * @param typeReference The TypeReference that should be used to de-serialze
+     * @param typeReference The TypeReference that should be used to de-serialize
      * the payload.
      * @return An instance of clazz filled with data from the payload.
      */

--- a/doctester-core/src/main/java/org/doctester/testbrowser/Response.java
+++ b/doctester-core/src/main/java/org/doctester/testbrowser/Response.java
@@ -15,7 +15,6 @@
  */
 package org.doctester.testbrowser;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.Map;
 
 import org.slf4j.Logger;
@@ -87,15 +86,12 @@ public class Response {
      */
     public String payloadAsPrettyString() {
 
-        if (isContentTypeApplicationJson(headers)) {
-
-            return getPrettyFormattedJson(payload);
-
-        } else {
-
-            return payload;
+        try {
+            return PayloadUtils.prettyPrintResponsePayload(payload, headers);
+        } catch (IOException ex) {
+            logger.error("Something went wrong when pretty printing response payload: " + ex.toString());
+            return "Error pretty printing the payload.";
         }
-
     }
 
     /**
@@ -112,9 +108,9 @@ public class Response {
 
         T parsedBody = null;
 
-        if (isContentTypeApplicationXml(headers)) {
+        if (PayloadUtils.isContentTypeApplicationXml(headers)) {
             parsedBody = payloadXmlAs(clazz);
-        } else if (isContentTypeApplicationJson(headers)) {
+        } else if (PayloadUtils.isContentTypeApplicationJson(headers)) {
             parsedBody = payloadJsonAs(clazz);
         } else {
             logger.error("Could neither find application/json or application/xml content type in response. Returning null.");
@@ -212,61 +208,6 @@ public class Response {
         }
 
         return parsedBody;
-    }
-
-    private boolean isContentTypeApplicationJson(Map<String, String> headers) {
-
-        String contentType = headers.get(HttpConstants.HEADER_CONTENT_TYPE);
-
-        if (contentType == null) {
-            return false;
-        }
-
-        if (contentType != null
-                && contentType.contains(HttpConstants.APPLICATION_JSON)) {
-
-            return true;
-
-        } else {
-            return false;
-        }
-
-    }
-
-    private boolean isContentTypeApplicationXml(Map<String, String> headers) {
-
-        String contentType = headers.get(HttpConstants.HEADER_CONTENT_TYPE);
-
-        if (contentType != null
-                && contentType.contains(HttpConstants.APPLICATION_XML)) {
-
-            return true;
-
-        } else {
-            return false;
-        }
-
-    }
-
-    private String getPrettyFormattedJson(String stringToFormatAsPrettyJson) {
-        String formattedJsonString;
-
-        try {
-            Object json = objectMapper.readValue(stringToFormatAsPrettyJson, Object.class);
-
-            formattedJsonString = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(json);
-
-        } catch (IOException ex) {
-
-            logger.error("Error formatting Content-Type application/json. "
-                    + "Something is strange. Either this is no json, or the header is wrong. "
-                    + "Returning unformatted string", ex);
-            formattedJsonString = stringToFormatAsPrettyJson;
-
-        }
-
-        return formattedJsonString;
-
     }
 
 }

--- a/doctester-core/src/site/markdown/developer/changelog.md
+++ b/doctester-core/src/site/markdown/developer/changelog.md
@@ -1,3 +1,7 @@
+Version 1.1.7
+=============
+ * 2015-05-22 Print pretty-printed payload (JSON/XML) in report when sayAndMakeRequest(Request) 
+
 Version 1.1.6
 =============
 

--- a/doctester-core/src/test/java/org/doctester/rendermachine/RenderMachineImplTest.java
+++ b/doctester-core/src/test/java/org/doctester/rendermachine/RenderMachineImplTest.java
@@ -69,4 +69,24 @@ public class RenderMachineImplTest {
                         + "</pre></div></dd>")
         );
     }
+
+    @Test
+    public void testThatXmlPayloadIsPrinted() {
+        User user = new User("xmlPayloadTester", "test456", "XML Payload Tester");
+        Request requestWithXmlPayload = Request.POST().url(Url.host("host")).contentTypeApplicationXml().payload(user);
+
+        when(testBrowser.makeRequest(requestWithXmlPayload)).thenReturn(new Response(ImmutableMap.of("header", "header"), 200, "payload"));
+
+        renderMachine.sayAndMakeRequest(requestWithXmlPayload);
+
+        String prettyPrintXml = requestWithXmlPayload.payloadAsPrettyString();
+        System.err.println(prettyPrintXml);
+        assertTrue(prettyPrintXml.startsWith("<"));
+        assertTrue(prettyPrintXml.contains("<username>xmlPayloadTester</username>"));
+        assertTrue(renderMachine.htmlDocument.contains(
+                "<dt>Content</dt><dd><div class=\"http-body\"><pre>"
+                        + HtmlEscapers.htmlEscaper().escape(prettyPrintXml)
+                        + "</pre></div></dd>")
+        );
+    }
 }

--- a/doctester-core/src/test/java/org/doctester/rendermachine/RenderMachineImplTest.java
+++ b/doctester-core/src/test/java/org/doctester/rendermachine/RenderMachineImplTest.java
@@ -61,7 +61,8 @@ public class RenderMachineImplTest {
         renderMachine.sayAndMakeRequest(requestWithJsonPayload);
 
         String prettyPrintJson = requestWithJsonPayload.payloadAsPrettyString();
-        assertTrue(prettyPrintJson.startsWith("{") || prettyPrintJson.startsWith("["));
+        assertTrue(prettyPrintJson.startsWith("{"));
+        assertTrue(prettyPrintJson.contains("\"jsonPayloadTester\""));
         assertTrue(renderMachine.htmlDocument.contains(
                 "<dt>Content</dt><dd><div class=\"http-body\"><pre>"
                         + HtmlEscapers.htmlEscaper().escape(prettyPrintJson)

--- a/doctester-core/src/test/java/org/doctester/rendermachine/RenderMachineImplTest.java
+++ b/doctester-core/src/test/java/org/doctester/rendermachine/RenderMachineImplTest.java
@@ -1,6 +1,7 @@
 package org.doctester.rendermachine;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.html.HtmlEscapers;
 import org.doctester.testbrowser.Request;
 import org.doctester.testbrowser.Response;
 import org.doctester.testbrowser.TestBrowser;
@@ -12,6 +13,8 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.Map;
+import org.doctester.testbrowser.testmodels.Article;
+import org.doctester.testbrowser.testmodels.User;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -46,5 +49,23 @@ public class RenderMachineImplTest {
 
         renderMachine.sayAndMakeRequest(requestWithParameters);
         assertTrue(renderMachine.htmlDocument.contains("<dt>Parameters</dt><dd>" + formParameters.toString() + "</dd>"));
+    }
+
+    @Test
+    public void testThatJsonPayloadIsPrinted() {
+        User user = new User("jsonPayloadTester", "test123", "JSON Payload Tester");
+        Request requestWithJsonPayload = Request.POST().url(Url.host("host")).contentTypeApplicationJson().payload(user);
+
+        when(testBrowser.makeRequest(requestWithJsonPayload)).thenReturn(new Response(ImmutableMap.of("header", "header"), 200, "payload"));
+
+        renderMachine.sayAndMakeRequest(requestWithJsonPayload);
+
+        String prettyPrintJson = requestWithJsonPayload.payloadAsPrettyString();
+        assertTrue(prettyPrintJson.startsWith("{") || prettyPrintJson.startsWith("["));
+        assertTrue(renderMachine.htmlDocument.contains(
+                "<dt>Content</dt><dd><div class=\"http-body\"><pre>"
+                        + HtmlEscapers.htmlEscaper().escape(prettyPrintJson)
+                        + "</pre></div></dd>")
+        );
     }
 }

--- a/doctester-core/src/test/java/org/doctester/rendermachine/RenderMachineImplTest.java
+++ b/doctester-core/src/test/java/org/doctester/rendermachine/RenderMachineImplTest.java
@@ -64,7 +64,7 @@ public class RenderMachineImplTest {
         assertTrue(prettyPrintJson.startsWith("{"));
         assertTrue(prettyPrintJson.contains("\"jsonPayloadTester\""));
         assertTrue(renderMachine.htmlDocument.contains(
-                "<dt>Content</dt><dd><div class=\"http-body\"><pre>"
+                "<dt>Content</dt><dd><div class=\"http-request-body\"><pre>"
                         + HtmlEscapers.htmlEscaper().escape(prettyPrintJson)
                         + "</pre></div></dd>")
         );
@@ -84,7 +84,7 @@ public class RenderMachineImplTest {
         assertTrue(prettyPrintXml.startsWith("<"));
         assertTrue(prettyPrintXml.contains("<username>xmlPayloadTester</username>"));
         assertTrue(renderMachine.htmlDocument.contains(
-                "<dt>Content</dt><dd><div class=\"http-body\"><pre>"
+                "<dt>Content</dt><dd><div class=\"http-request-body\"><pre>"
                         + HtmlEscapers.htmlEscaper().escape(prettyPrintXml)
                         + "</pre></div></dd>")
         );


### PR DESCRIPTION
Pretty prints the payload when Content-Type is either JSON or XML. I'm not overly happy with the PayloadUtils class, but gets the job done.. 

It's might also be problem that ObjectMapper and XmlMapper instances are not user-configurable, which practically makes testing models with, for example, Java 8 DateTime fields much harder (support via [Jackson JSR-310 datatype module](https://github.com/FasterXML/jackson-datatype-jsr310)). 