### PR TITLE
Implemented support for HTTP PATCH requests

### DIFF
--- a/doctester-core/src/main/java/org/doctester/testbrowser/HttpConstants.java
+++ b/doctester-core/src/main/java/org/doctester/testbrowser/HttpConstants.java
@@ -39,5 +39,6 @@ public interface HttpConstants {
     String DELETE = "DELETE";
     String POST = "POST";
     String PUT = "PUT";
+    String PATCH = "PATCH";
 
 }

--- a/doctester-core/src/main/java/org/doctester/testbrowser/Request.java
+++ b/doctester-core/src/main/java/org/doctester/testbrowser/Request.java
@@ -126,6 +126,22 @@ public class Request {
 
     /**
      *
+     * Get a request to perform a Http PATCH request via the TestBrowser.
+     *
+     * @return A request configured for a Http PATCH request.
+     *
+     */
+    public static Request PATCH() {
+
+        Request httpRequest = new Request();
+        httpRequest.httpRequestType = HttpConstants.PATCH;
+
+        return httpRequest;
+
+    }
+
+    /**
+     *
      * Get a request to perform a Http DELETE request via the TestBrowser.
      *
      * @return A request configured for a DELETE request.

--- a/doctester-core/src/main/java/org/doctester/testbrowser/TestBrowserImpl.java
+++ b/doctester-core/src/main/java/org/doctester/testbrowser/TestBrowserImpl.java
@@ -15,26 +15,17 @@
  */
 package org.doctester.testbrowser;
 
-import java.io.File;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-
-import javax.management.RuntimeErrorException;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpVersion;
+import org.apache.http.ParseException;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
-import org.apache.http.client.methods.HttpDelete;
-import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpHead;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpPut;
-import org.apache.http.client.methods.HttpRequestBase;
-import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.methods.*;
 import org.apache.http.cookie.Cookie;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.entity.mime.HttpMultipartMode;
@@ -49,12 +40,12 @@ import org.apache.http.util.EntityUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.xml.XmlMapper;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
+import javax.management.RuntimeErrorException;
+import java.io.File;
 import java.io.IOException;
-import org.apache.http.ParseException;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 
 import static org.doctester.testbrowser.HttpConstants.*;
 
@@ -105,9 +96,9 @@ public class TestBrowserImpl implements TestBrowser {
 
             httpResponse = makeHeadGetOrDeleteRequest(httpRequest);
 
-        } else if (Sets.newHashSet(POST, PUT).contains(httpRequest.httpRequestType)) {
+        } else if (Sets.newHashSet(POST, PUT, PATCH).contains(httpRequest.httpRequestType)) {
 
-            httpResponse = makePostOrPutRequest(httpRequest);
+            httpResponse = makePatchPostOrPutRequest(httpRequest);
 
         } else {
 
@@ -173,7 +164,7 @@ public class TestBrowserImpl implements TestBrowser {
         return response;
     }
 
-    private Response makePostOrPutRequest(Request httpRequest) {
+    private Response makePatchPostOrPutRequest(Request httpRequest) {
 
         org.apache.http.HttpResponse apacheHttpClientResponse;
         Response response = null;
@@ -185,7 +176,11 @@ public class TestBrowserImpl implements TestBrowser {
 
             HttpEntityEnclosingRequestBase apacheHttpRequest;
 
-            if (POST.equalsIgnoreCase(httpRequest.httpRequestType)) {
+            if (PATCH.equalsIgnoreCase(httpRequest.httpRequestType)) {
+
+                apacheHttpRequest = new HttpPatch(httpRequest.uri);
+
+            } else if (POST.equalsIgnoreCase(httpRequest.httpRequestType)) {
 
                 apacheHttpRequest = new HttpPost(httpRequest.uri);
 
@@ -290,7 +285,7 @@ public class TestBrowserImpl implements TestBrowser {
             apacheHttpRequest.releaseConnection();
 
         } catch (IOException e) {
-            logger.error("Fatal problem creating POST or PUT request in TestBrowser", e);
+            logger.error("Fatal problem creating PATCH, POST or PUT request in TestBrowser", e);
             throw new RuntimeException(e);
         }
 

--- a/doctester-core/src/test/java/org/doctester/testbrowser/RequestTest.java
+++ b/doctester-core/src/test/java/org/doctester/testbrowser/RequestTest.java
@@ -16,19 +16,13 @@
 package org.doctester.testbrowser;
 
 import com.google.common.collect.Maps;
+import org.junit.Test;
+
 import java.io.File;
 import java.util.Map;
-import org.hamcrest.CoreMatchers;
-import org.junit.After;
-import org.junit.AfterClass;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
 
 /**
  *
@@ -57,6 +51,13 @@ public class RequestTest {
 
         Request result = Request.POST();
         assertThat(result.httpRequestType, equalTo("POST"));
+    }
+
+    @Test
+    public void testPATCH() {
+
+        Request result = Request.PATCH();
+        assertThat(result.httpRequestType, equalTo("PATCH"));
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -138,5 +138,19 @@ the specific language governing permissions and limitations under the License. -
 		<org-netbeans-modules-editor-indent.CodeStyle.project.indent-shift-width>4</org-netbeans-modules-editor-indent.CodeStyle.project.indent-shift-width>
 		<org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.expand-tabs>false</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.expand-tabs>
 	</properties>
-		
+
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpclient</artifactId>
+			<version>4.5.2</version>
+			<exclusions>
+				<exclusion>
+					<artifactId>commons-logging</artifactId>
+					<groupId>commons-logging</groupId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+	</dependencies>
+
 </project>


### PR DESCRIPTION
Using Request.PATCH(), it is now possible to make http PATCH (RFC 5789) requests.